### PR TITLE
Update MoveSelf() in MoveWithLevelRB.cs.

### DIFF
--- a/Space Battle Game/Assets/Scripts/Level Scripts/MoveWithLevelRB.cs
+++ b/Space Battle Game/Assets/Scripts/Level Scripts/MoveWithLevelRB.cs
@@ -18,6 +18,6 @@ public class MoveWithLevelRB : MonoBehaviour
 
     void MoveSelf(float xChange, float yChange)
     {
-        transform.position = new Vector2(transform.position.x + xChange, transform.position.y + yChange);
+        transform.position = new Vector3(transform.position.x + xChange, transform.position.y + yChange, transform.position.z);
     }
 }


### PR DESCRIPTION
Enemy ships' transform.position.z would change to 0 on Player Ship movement.
Identified MoveWithLevelRB.cs as being responsible.
The only change to the transform.position in this script is MoveSelf(float xChange, float yChange), which changes the transform to a Vector2 and adds the offset to x and y, but was setting z to 0.
Changed the Vector2 to a Vector3 and ensured that transform.position.z doesn't change.