### PR TITLE
Update EnemySpawner.cs, fixed waveNumber

### DIFF
--- a/Space Battle Game/Assets/Scripts/Enemy Scripts/EnemySpawner.cs
+++ b/Space Battle Game/Assets/Scripts/Enemy Scripts/EnemySpawner.cs
@@ -46,6 +46,7 @@ public class EnemySpawner : MonoBehaviour
             {
                 SpawnEnemies(Mathf.CeilToInt(waveNumber * 1.5f));
                 waveCooldownRemaining = waveCooldown;
+                waveNumber++;
             }
         }
 


### PR DESCRIPTION
Waves were always spawning 2 Enemy ships.
Identified that the variable waveNumber was not increasing.
Added waveNumber++ at line 49 to increase waveNumber every time a new wave of enemies is spawned.